### PR TITLE
Julian_Duran:_PongRL_Week_1

### DIFF
--- a/Assets/Source/Scripts/Pong/Ball/PongBallController.cs
+++ b/Assets/Source/Scripts/Pong/Ball/PongBallController.cs
@@ -34,6 +34,11 @@ namespace Pong.Ball {
         // initialization check
         private bool isInitialized = false;
 
+        /// <summary>
+        /// Initializes the events that will be interpreted as a point score and a rebound.
+        /// Onscore() and OnRebound() are called as functions during runtime.
+        /// </summary>
+        /// <returns>None</returns>
         public void Initialize(Action scoreProcedure, Action reboundProcedure) {
             OnScore = scoreProcedure;
             OnRebound = reboundProcedure;
@@ -54,6 +59,11 @@ namespace Pong.Ball {
         }
 
         // Update is called once per frame
+        /// <summary>
+        /// Updates the balls position every frame by calculating the current ball velocity,
+        /// then passing this velocity into the MoveLocal function that will move the ball.
+        /// </summary>
+        /// <returns>None</returns>
         void Update()
         {
             if (!isInitialized) {
@@ -71,7 +81,12 @@ namespace Pong.Ball {
             }
         }
 
-        //* Deals with Movement, and Collision + Interactions as a Result of that movement
+        /// <summary>
+        /// Moves the ball in the direction of the passed Vector3, and then calculates any
+        /// collisions or scoring positions that this movement may have placed the ball in.
+        /// Calls functions for scoring or rebounding depending on collision detection.
+        /// </summary>
+        /// <returns>None</returns>
         public void MoveLocal(Vector3 localDelta_dt) {
             // origin is in the center
             Vector3 MAX_POS = BG_TRANSFORM.localScale / 2f;

--- a/Assets/Source/Scripts/Pong/Ball/_Pong-Ball.cs
+++ b/Assets/Source/Scripts/Pong/Ball/_Pong-Ball.cs
@@ -11,6 +11,10 @@ namespace Pong.Ball {
      * Player lastTouchedBy
      * Destroys the ball and increments points
     */
+    /// <summary>
+    /// Represents the physical ball that is visible on game screen, and handles
+    /// ball logic such as scoring and serving
+    /// </summary>
     public partial class PongBall {}
 
     /*
@@ -18,6 +22,10 @@ namespace Pong.Ball {
        speedX = GameCache.BALL_SPEED_VP
        velocityY = ForceAdjustment => Equation (due to possible derivatives) 
     */
+    /// <summary>
+    /// Controls the physical ball that is visible on game screen, calculating
+    /// trajectory, movement, and collisions
+    /// </summary>
     public partial class PongBallController : MonoBehaviour {}
 
     /*public static class BallStatus {
@@ -37,6 +45,10 @@ namespace Pong.Ball {
         }
     }*/
 
+    /// <summary>
+    /// Defines constants for keeping track of which player scored last which is used
+    /// to determine which player's turn it is to serve
+    /// </summary>
     public static class BallGoal {
         public const bool LEFT = true;
         public const bool RIGHT = false;

--- a/Assets/Source/Scripts/Pong/GamePlayer/Player.cs
+++ b/Assets/Source/Scripts/Pong/GamePlayer/Player.cs
@@ -54,6 +54,11 @@ namespace Pong.GamePlayer {
             playerSprite = new ControlledGameObject<PlayerController>(sprite, controller);
         }
 
+        /// <summary>
+        /// Initializes a player object including setting the players name, passing them a paddle
+        /// object, setting their viewport view, and setting their controls.
+        /// </summary>
+        /// <returns>Player object</returns>
         public static Player CreateNew(string name, GameObject prefab, Vector2 viewportPos, PlayerControls controls, TMP_Text scoreText) {
             // create paddle
             GameObject paddle = GameObject.Instantiate(prefab, ToLocal(viewportPos), Quaternion.identity);
@@ -92,6 +97,10 @@ namespace Pong.GamePlayer {
             //TODO: playerData.feed(...);
         }
 
+        /// <summary>
+        /// Updates the scoreboard when Player scores a point.
+        /// </summary>
+        /// <returns>None</returns>
         public void ScorePoint() {
             // Game: score point
             scoreboard.ScorePoint();
@@ -105,6 +114,12 @@ namespace Pong.GamePlayer {
             return new Rebounder(forceMap, playerSprite.gameObj.GetComponent<RectangularBodyFrame>());
         }
 
+        /// <summary>
+        /// Sets the dimensions of a players paddle depending on the viewport dimensions which 
+        /// are passed in as two floats. Calculates correct dimensions regardless of viewport
+        /// size, allowing for scalability of game window.
+        /// </summary>
+        /// <returns>void</returns>
         public void SetLocalPaddleDimensionsFromVP(float vpXThickness, float vpYLength) {
             Vector3 bgScale = GameCache.BG_TRANSFORM.localScale;
 

--- a/Assets/Source/Scripts/Pong/GamePlayer/_Pong-GamePlayer.cs
+++ b/Assets/Source/Scripts/Pong/GamePlayer/_Pong-GamePlayer.cs
@@ -5,13 +5,28 @@ using System.Collections.Generic;
 using UnityEngine;
 
 namespace Pong.GamePlayer {
+    /// <summary>
+    /// Player object handles player actions such as initialization of  
+    /// paddle size and collision ‘walls’, paddle movement and sprite initialization,
+    /// and scoring 
+    /// </summary>
     public partial class Player {}
 
+    /// <summary>
+    /// Stores player data and gameplay history for use in RL training
+    /// </summary>
     public partial class PlayerData : ScriptableObject {}
     //public partial class AIPlayerData : PlayerData {}
 
+    /// <summary>
+    /// Controls the physical player paddle that appears on the game screen, as well
+    /// as interpreting user input from keyboard controls.
+    /// </summary>
     public partial class PlayerController : MonoBehaviour {}
 
+    /// <summary>
+    /// Stores player control scheme
+    /// </summary>
     public class PlayerControls {
         public readonly KeyCode Up, Down;
         public PlayerControls(KeyCode up, KeyCode down) {

--- a/Assets/Source/Scripts/Pong/Physics/Motion2D.cs
+++ b/Assets/Source/Scripts/Pong/Physics/Motion2D.cs
@@ -12,6 +12,11 @@ namespace Pong.Physics {
         public Vector2 velocity = new Vector2(0f, 0f);
         public readonly float[] yAccelerationAndBeyond = new float[GameConstants.BALL_Y_MAX_DERIVATIVE - 1];
 
+        /// <summary>
+        /// Creates a new Motion2D object with a pre-set velocity that is specified
+        /// by the input Vector2
+        /// </summary>
+        /// <returns>Motion2D object</returns>
         public Motion2D(Vector2 velocity2f) {
             velocity.Set(velocity2f.x, velocity2f.y);
             ResetYAccelerationAndBeyond();
@@ -39,6 +44,12 @@ namespace Pong.Physics {
             ResetYAccelerationAndBeyond();
         }
 
+        /// <summary>
+        /// Calculates the velocity vector for an object given an input t which represents
+        /// the elapsed trajectory time. This function is called every frame as part of the
+        /// PongBall's update() function.
+        /// </summary>
+        /// <returns>2 dimensional velocity vector</returns>
         public Vector2 CalculateTotalVelocity(float t) {
             Vector2 totalVelocity = new Vector2(velocity.x, velocity.y);
 
@@ -56,6 +67,13 @@ namespace Pong.Physics {
         }
 
         // [(x, y), (x', y'), (x'', y''), ...]
+        /// <summary>
+        /// Takes in a single 2 dimensional vector representing position and returns an array of
+        /// pairs of vectors representing higher derivatives of position and velocity.
+        /// NOTE: higher derivatives of position are always 0, whereas higher derivatives of
+        /// velocity represent acceleration, jerk, etc..
+        /// </summary>
+        /// <returns>An series of 2-dimensional vectors</returns>
         public Vector2[] RetrieveTrajectory(Vector2 position) {
             Vector2[] trajectory = new Vector2[2 + yAccelerationAndBeyond.Length]; // position and velocity are included too!
 

--- a/Assets/Source/Scripts/Pong/_Pong.cs
+++ b/Assets/Source/Scripts/Pong/_Pong.cs
@@ -7,6 +7,12 @@ using UnityEngine;
 using Pong.GamePlayer;
 
 namespace Pong {
+
+    /// <summary>
+    /// Contains many global game constants that are crucial for game initialization
+    /// and runtime game logic including physics constants, viewport scaling constants,
+    /// and viewport position constants
+    /// </summary>
     public static class GameConstants {
         // must be >= 1 because velocity is required
         public const uint BALL_Y_MAX_DERIVATIVE = 3; // velocity + (acceleration, acceleration')
@@ -40,6 +46,11 @@ namespace Pong {
         public static readonly char[] WINDOWS_BANNED_CHARS = {'\\', '/', ':', '*', '?', '\"', '<', '>', '|'};
     }
 
+    /// <summary>
+    /// Contains variables that are passed into the GameManager and set by the GameManager
+    /// during runtime. Variables effect player speed, ball speed, serve and bounce angle
+    /// maximums, and the win condition.
+    /// </summary>
     public static class GameCache {
         // cached at the beginning of GameManager
         public static Transform BG_TRANSFORM;
@@ -55,6 +66,10 @@ namespace Pong {
         public static bool MUTE_SOUNDS = false; // when turned on, audio won't be played
     }
 
+    /// <summary>
+    /// Helper functions for computing vectors during runtime, such as casting a 3d vector
+    /// to a 2d vector or vice versa.
+    /// </summary>
     public static class GameHelpers {
         public static Vector2 ToVector2(Vector3 vector) {
             return new Vector2(vector.x, vector.y);


### PR DESCRIPTION
# Code Exploration: 

## REQUIRED 

**Pong/_Pong.cs:**

Contains declarations of many constants that are used throughout the game logic, as well as initializations for some crucial constants such as maximum score, default win score etc 
`class GameConstants`: contains many constant declarations for game logic 
`class GameCache`: caches global variables that are needed at runtime 
`float ballSpeedVP`: global variable for ball speed 

**Pong/GamePlayer/_Pong-GamePlayer.cs** 

Contains declarations for several player-related variables and classes, as well as defining the namespace for player objects. Contains definitions of player controls (up/down). 
`KeyCode Up, Down`: player controls for in-game 
`class Player`: stores information about players, as well as many functions that will run during gameplay and are crucial to game logic

**Pong/Ball/_Pong-Ball.cs** 

Class implementation for the ball object that is crucial to the game. Contains functions for different ball behavior during the course of the game, including serves, game resets, and scores. Also contains logic for keeping track of which player is currently the ‘attacker’. 
`OnScore()`: resets ball and updates scoreboard when player scores 
`OnRebound()`: updates ball state when player hits ball 
`Reset()`: resets ball to initial position 
`SetLocalScaleFromVPY()`: decides ball scale based on current size of game window 


## CHOSEN 

**Pong/Ball/PongBallController.cs** 

Handles physics, movement, and collision of the PongBall object. Calculates trajectory of ball movement based on viewport size and initial trajectory, as well as scoring logic and wall collisions. 
`void Update()`: called every frame, moves ball on screen 
`void MoveLocal()`: calculates ball movement for Update() 
`void ResetBallState()`: resets the ball state (wow no way dude) 

**Pong/GamePlayer/Player.cs** 

Handles player creation and player actions such as initialization of paddle size and collision ‘walls’, paddle movement and sprite initialization, and scoring 
`void Update()`: appears to be called every frame (?) to update paddle movement 
`void ScorePoint()`: scores a point for the player (woahh no way) 
`void SetLocalPaddleDimensionsFromVP()`: decides the on-screen dimensions of the paddle depending on the size of the game window 

**Pong/Physics/RectangularBodyFrame.cs** 

Handles collisions of game objects by calculating their edges and then running constant collision state calculations, only using this information when a collision actually occurs 
`void Update()`: updates where the ‘edges’ of a game object are 
`bool CollidesWith()`: determines if a collision between two game objects actually happened 
`vector2 CollisionPoint()`: returns the angle of a collision between two game objects (?) 


# TESTING 

Changes in Pong/GameManager.cs 

    ballSpeedVP = 0.90f 

    playerSpeedVP = 3.00f 

I expected these changes to double the speed of the ball and triple the speed of the player paddle, but strangely these changes did nothing, even after reloading the project completely in Unity. This was confusing to me, as I searched deeper and could not find any other place where the ball speed or player speed variables are initialized. Ether I am missing something important about how global variables are handled, there is a problem with how I’m trying to edit the files, or something I don’t understand about Unity. 

Changes in Pong/_Pong.cs 

    RIGHT_PADDLE_START_POSITION, LEFT_PADDLE_START_POSITION values swapped 

This was an interesting exploration, as it not only affected which controls mapped to which paddle on the screen but also the scoring. It appeared to reverse the scoring, where the ‘losing’ side instead received a point and the ‘winning’ side did not. This is predictable because the scoring is calculated based on which player touched the ball last, not which edge the ball went over, so essentially the scoreboard is reversed. If the two scoreboard numbers were switched this change would basically do nothing.  

Changes in Pong/Physics/RectangularBodyFrame.cs 

    Swapped boolean output logic in CollidesWith() 

This change caused the ball to stay still in the center of the screen, appearing unable to move at all. I’m assuming this is caused by the game constantly expecting the ball to be involved in a collision, and therefore it is waiting for a direction to be specified to move the ball in after the collision. Obviously no direction is ever specified, so the ball stays still. Interestingly, after this discover I changed 

    Pong/_Pong.cs 

So that one of the paddles started in the center of the screen, shifted slightly upwards so it didn’t begin in contact with the ball. When the paddle is moved downwards into the ball, the ball shifts slightly in a random direction and then stops again. I would imagine the distance that the ball moves is the amount it travels in one ‘tick’ of game time before an update function is called again. Also, the fact that the ball moves in a seemingly random direction is interesting, as it indicates an element of randomness in the collision vector calculations (could be unexpected behavior due to location of collision with paddle). 

## Documentation
- Non-header file #1 `Assets/Source/Scripts/Pong/Ball/PongBallController.cs`
- Non-header file #2 `Assets/Source/Scripts/Pong/GamePlayer/Player.cs`
- Non-header file #3 `Assets/Source/Scripts/Pong/Physics/Motion2D.cs`
- Header file #1 `Assets/Source/Scripts/Pong/Ball/_Pong-Ball.cs`
- Header file #2 `Assets/Source/Scripts/Pong/GamePlayer/_Pong-GamePlayer.cs`
- Header file #3 `Assets/Source/Scripts/Pong/_Pong.cs`